### PR TITLE
Revise test wording

### DIFF
--- a/spec/features/user_features_spec.rb
+++ b/spec/features/user_features_spec.rb
@@ -49,7 +49,7 @@ describe 'Feature Test: User Signup', :type => :feature do
     )
     visit '/users/1'
     expect(current_path).to eq('/')
-    expect(page).to have_content("Sign Up")
+    expect(page).to have_content("Sign up")
   end
 
   it 'successfully signs up as admin' do

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Ride, :type => :model do
 
   it "has a method 'take_ride' that accounts for the user not having enough tickets" do
     ride = Ride.create(:user_id => user.id, :attraction_id => attraction.id)
-    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets the #{attraction.name}.")
+    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets to ride the #{attraction.name}.")
     expect(user.tickets).to eq(4)
     expect(user.happiness).to eq(3)
     expect(user.nausea).to eq(5)
@@ -58,7 +58,7 @@ RSpec.describe Ride, :type => :model do
   it "has a method 'take_ride' that accounts for the user not being tall enough and not having enough tickets" do
     user.update(:height => 30)
     ride = Ride.create(:user_id => user.id, :attraction_id => attraction.id)
-    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets the #{attraction.name}. You are not tall enough to ride the #{attraction.name}.")
+    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets to ride the #{attraction.name}. You are not tall enough to ride the #{attraction.name}.")
     expect(user.tickets).to eq(4)
     expect(user.happiness).to eq(3)
     expect(user.nausea).to eq(5)


### PR DESCRIPTION
There were two instances where the wording in 2 different rspec tests was contradictory:

On **line 5** of **/spec/support/login_helper.rb** it says:
`click_link('Sign up')`
But **line 52** of **/spec/features/user_features_spec.rb** checks for:
`expect(page).to have_content("Sign up")`
so if a user labeled their signup link/button as 'Sign Up' with a capital 'U', it would fail the first test, but if they labeled it 'Sign up' with a lowercase 'u', it would fail the second test.

**Lines 252 and 263** of **/spec/features/user_features_spec.rb** check for:
`expect(page).to have_content("You do not have enough tickets to ride the #{@ferriswheel.name}")`
But **lines 43 and 61** of **/spec/models/ride_spec.rb** say:
`expect(ride.take_ride).to eq("Sorry. You do not have enough tickets the #{attraction.name}.")`
which is missing the " to ride " part of the sentence.

